### PR TITLE
Fix missing gradle metadata preview

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,3 @@
 rootProject.name = "fluid-library"
+
+enableFeaturePreview("GRADLE_METADATA")


### PR DESCRIPTION
Having his unfortunately doesn't fail the build, but generates a broken publication for
projects using experimental Kotlin multiplatform.